### PR TITLE
ユーザーフォロー／フォロワー一覧が見られる／フォロー一覧が見られる

### DIFF
--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -142,7 +142,7 @@ class UserController extends Controller
      */
     public function getFollowedUsers(Follower $follower): View
     {
-        $loginUserId = auth()->user()->id;
+        $loginUserId = auth()->id();
         $followed = $follower->getAllFollowedUserByUserId($loginUserId);
 
         return view('user.followed', compact('followed'));

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Models\Follower;
 use App\Http\Requests\UserUpdateRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\RedirectResponse;
@@ -86,5 +87,41 @@ class UserController extends Controller
     public function getAll(): View
     {
         return view('user.index', ['users' => User::all()]);
+    }
+
+    // フォロー
+    public function follow(Int $user_id)
+    {
+        $follower = auth()->user();
+        $is_following = $follower->isFollowing($user_id); //フォローしているかチェック
+        if(!$is_following) {
+            $follower->follow($user_id);
+        }
+        return back();
+    }
+
+    // フォロー解除
+    public function unfollow(Int $user_id)
+    {
+        $follower = auth()->user();
+        $is_following = $follower->isFollowing($user_id); //フォローしているかチェック
+        if($is_following) {
+            $follower->unfollow($user_id);
+        }
+        return back();
+    }
+
+    public function getAllFollowers(Follower $follower)
+    {
+        $loginUserId = auth()->user()->id;
+        $followers = $follower->getAllFollowers($loginUserId);
+        return view('user.follower', compact('followers'));
+    }
+
+    public function getFollowedUsers(Follower $follower)
+    {
+        $loginUserId = auth()->user()->id;
+        $followed = $follower->getAllFollowedUserByUserId($loginUserId);
+        return view('user.followed', compact('followed'));
     }
 }

--- a/twitter/app/Http/Controllers/UserController.php
+++ b/twitter/app/Http/Controllers/UserController.php
@@ -14,11 +14,11 @@ class UserController extends Controller
     /**
      * ユーザーIDを取得
      *
-     * @param integer $userId
+     * @param Int $userId
      * @param User $user
-     * @return View|RedirectResponse
+     * @return User
      */
-    public function findByUserId(int $userId, User $user): User
+    public function findByUserId(Int $userId, User $user): User
     {
         //ログイン中のIDを取得
         if(Auth::id() !== $userId) {
@@ -27,17 +27,17 @@ class UserController extends Controller
         return $user->findByUserId($userId);
     }
 
-
     /**
      * ユーザー詳細画面を表示
      *
-     * @param integer $userId
+     * @param Int $userId
      * @param User $user
      * @return View
      */
-    public function show(int $userId, User $user): View
+    public function show(Int $userId, User $user): View
     {
         $userDetail = $this->findByUserId($userId, $user);
+
         return view('user.show', ['userDetail' => $userDetail]);
     }
 
@@ -59,6 +59,7 @@ class UserController extends Controller
         ];
 
         $user->update($data);
+
         return redirect()->route('home')
             ->with('success', 'ユーザー情報が更新されました！');
     }
@@ -89,39 +90,61 @@ class UserController extends Controller
         return view('user.index', ['users' => User::all()]);
     }
 
-    // フォロー
-    public function follow(Int $user_id)
+    /**
+     * フォローする処理
+     *
+     * @param Int $userId
+     * @return RedirectResponse
+     */
+    public function follow(Int $userId): RedirectResponse
     {
         $follower = auth()->user();
-        $is_following = $follower->isFollowing($user_id); //フォローしているかチェック
-        if(!$is_following) {
-            $follower->follow($user_id);
-        }
+        $isFollowing = $follower->isFollowing($userId); //フォローしているかチェック
+        if(!$isFollowing) $follower->follow($userId);
+
         return back();
     }
 
-    // フォロー解除
-    public function unfollow(Int $user_id)
+    /**
+     * フォロー解除処理
+     *
+     * @param Int $userId
+     * @return RedirectResponse
+     */
+    public function unfollow(Int $userId): RedirectResponse
     {
         $follower = auth()->user();
-        $is_following = $follower->isFollowing($user_id); //フォローしているかチェック
-        if($is_following) {
-            $follower->unfollow($user_id);
-        }
+        $isFollowing = $follower->isFollowing($userId); //フォローしているかチェック
+        if($isFollowing) $follower->unfollow($userId);
+
         return back();
     }
 
-    public function getAllFollowers(Follower $follower)
+    /**
+     * フォローされているユーザーを表示
+     *
+     * @param Follower $follower
+     * @return View
+     */
+    public function getAllFollowers(Follower $follower): View
     {
-        $loginUserId = auth()->user()->id;
+        $loginUserId = auth()->id();
         $followers = $follower->getAllFollowers($loginUserId);
+
         return view('user.follower', compact('followers'));
     }
 
-    public function getFollowedUsers(Follower $follower)
+    /**
+     * フォローしているユーザーを表示
+     *
+     * @param Follower $follower
+     * @return View
+     */
+    public function getFollowedUsers(Follower $follower): View
     {
         $loginUserId = auth()->user()->id;
         $followed = $follower->getAllFollowedUserByUserId($loginUserId);
+
         return view('user.followed', compact('followed'));
     }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -46,11 +46,11 @@ class Follower extends Model
      * フォロワー一覧を取得
      *
      * @param Int $loginUserId
-     * @return Collection|array
+     * @return Collection
      */
     public function getAllFollowers(Int $loginUserId): Collection
     {
-        return $followers = auth()->user()->followers()->get();
+        return auth()->user()->followers()->get();
     }
 
     /**
@@ -61,6 +61,6 @@ class Follower extends Model
      */
     public function getAllFollowedUserByUserId(Int $loginUserId): Collection
     {
-        return $follows = auth()->user()->follows()->get();
+        return auth()->user()->follows()->get();
     }
 }

--- a/twitter/app/Models/Follower.php
+++ b/twitter/app/Models/Follower.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Follower extends Model
+{
+    use HasFactory;
+
+    /**
+     *リレーション(フォローするユーザーを取得)
+     *
+     * @return BelongsToMany
+     */
+    public function follow(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'followers', 'following_id', 'followed_id');
+    }
+
+    /**
+     * リレーション(フォローしているユーザーを取得)
+     *
+     * @return belongsTo
+     */
+    public function following(): belongsTo
+    {
+        return $this->belongsTo(User::class, 'following_id');
+    }
+
+    /**
+     * リレーション(フォローされているユーザーを取得)
+     *
+     * @return belongsTo
+     */
+    public function followed(): belongsTo
+    {
+        return $this->belongsTo(User::class, 'followed_id');
+    }
+
+    /**
+     * フォロワー一覧を取得
+     *
+     * @param Int $loginUserId
+     * @return Collection|array
+     */
+    public function getAllFollowers(Int $loginUserId): Collection
+    {
+        return $followers = auth()->user()->followers()->get();
+    }
+
+    /**
+     * フォロー一覧を取得
+     *
+     * @param Int $loginUserId
+     * @return Collection
+     */
+    public function getAllFollowedUserByUserId(Int $loginUserId): Collection
+    {
+        return $follows = auth()->user()->follows()->get();
+    }
+}

--- a/twitter/app/Models/User.php
+++ b/twitter/app/Models/User.php
@@ -69,15 +69,17 @@ class User extends Authenticatable
     /**
      * ユーザーIDに一致するユーザーを削除
      *
-     * @param string $userId
+     * @param Int $userId
+     * @return void
      */
-    public function userDelete(string $userId)
+    public function userDelete(Int $userId)
     {
         $user = static::find($userId);
 
         if($user) {
             $user->delete();
         }
+        
         return $user;
     }
 
@@ -92,7 +94,7 @@ class User extends Authenticatable
     }
 
     /**
-     * Undocumented function
+     * 中間テーブル(followersテーブルの設定)
      *
      * @return belongsToMany
      */
@@ -101,6 +103,11 @@ class User extends Authenticatable
         return $this->belongsToMany(User::class, 'followers', 'following_id', 'followed_id');
     }
 
+    /**
+     * 中間テーブル(followersテーブルの設定)
+     *
+     * @return void
+     */
     public function followers()
     {
         return $this->belongsToMany(User::class, 'followers', 'followed_id', 'following_id');

--- a/twitter/database/migrations/2023_08_14_070503_create_followers_table.php
+++ b/twitter/database/migrations/2023_08_14_070503_create_followers_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('followers', function (Blueprint $table) {
+            $table->unsignedInteger('following_id')->comment('フォローしているユーザID');
+            $table->unsignedInteger('followed_id')->comment('フォローされているユーザID');
+
+            $table->unique([
+                'following_id',
+                'followed_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('followers');
+    }
+};

--- a/twitter/database/seeders/FollowersTableSeeder.php
+++ b/twitter/database/seeders/FollowersTableSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class FollowersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for ($i = 2; $i <= 10; $i++) {
+            Follower::create([
+                'following_id' => $i,
+                'followed_id' => 1
+            ]);
+    }
+}

--- a/twitter/resources/views/components/header.blade.php
+++ b/twitter/resources/views/components/header.blade.php
@@ -37,7 +37,7 @@
                         <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                             <a  class="dropdown-item"  href="{{ route('user.show', Auth::id()) }}">ユーザー詳細</a>
 
-                            <a  class="dropdown-item"  href="{{ route('user.index') }}">ユーザー一覧</a>
+                            <a  class="dropdown-item"  href="{{ route('users.index') }}">ユーザー一覧</a>
 
                             <a class="dropdown-item" href="{{ route('logout') }}"
                                 onclick="event.preventDefault();

--- a/twitter/resources/views/user/followed.blade.php
+++ b/twitter/resources/views/user/followed.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('title', 'ホーム')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <h2>Follow List</h2>
+                @foreach ($followed as $follow)
+                    {{-- ログイン中のユーザーは非表示に --}}
+                    <div class="card">
+                        <div class="card-haeder p-3 w-100 d-flex">
+                            <img src="" class="rounded-circle" width="50" height="50">
+                            <div class="ml-2 d-flex flex-column">
+                                <p class="mb-0">{{ $follow->name }}</p>
+                                <a href="{{ url('users/' . $follow->id) }}"
+                                    class="text-secondary">{{ $follow->screen_name }}</a>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+@endsection

--- a/twitter/resources/views/user/follower.blade.php
+++ b/twitter/resources/views/user/follower.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('title', 'ホーム')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <h2>Follower List</h2>
+                @foreach ($followers as $follower)
+                    {{-- ログイン中のユーザーは非表示に --}}
+                    <div class="card">
+                        <div class="card-haeder p-3 w-100 d-flex">
+                            <img src="" class="rounded-circle" width="50" height="50">
+                            <div class="ml-2 d-flex flex-column">
+                                <p class="mb-0">{{ $follower->name }}</p>
+                                <a href="{{ url('users/' . $follower->id) }}"
+                                    class="text-secondary">{{ $follower->screen_name }}</a>
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+@endsection

--- a/twitter/resources/views/user/index.blade.php
+++ b/twitter/resources/views/user/index.blade.php
@@ -1,13 +1,54 @@
 @extends('layouts.app')
 
-@section('title', 'ユーザー一覧')
-
 @section('content')
-  <h2>ユーザー一覧</h2>
-  @foreach($users as $user)
-    <ul>
-      <li>ユーザー名：{{ $user->name }}</li>
-      <li>メールアドレス：{{ $user->email }}</li>
-    </ul>
-  @endforeach
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <p>
+                    <a href="{{ route('users.getFollowedUsers') }}">フォロー一覧</a>
+                </p>
+                <p>
+                    <a href="{{ route('users.getFollowers') }}">フォロワー一覧</a>
+                </p>
+                @foreach ($users as $user)
+                    {{-- ログイン中のユーザーは非表示に --}}
+                    @if (auth()->check() && $user->id !== auth()->user()->id)
+                        <div class="card">
+                            <div class="card-haeder p-3 w-100 d-flex">
+                                <img src="{{ $user->profile_image }}" class="rounded-circle" width="50" height="50">
+                                <div class="ml-2 d-flex flex-column">
+                                    <p class="mb-0">{{ $user->name }}</p>
+                                    <a href="{{ url('users/' . $user->id) }}"
+                                        class="text-secondary">{{ $user->screen_name }}</a>
+                                </div>
+
+                                @if (auth()->user()->isFollowed($user->id))
+                                    <div class="px-2">
+                                        <span class="px-1 bg-secondary text-light">フォローされています</span>
+                                    </div>
+                                @endif
+
+                                <div class="d-flex justify-content-end flex-grow-1">
+                                    @if (auth()->user()->isFollowing($user->id))
+                                        <form action="{{ route('users.unfollow', ['id' => $user->id]) }}" method="POST">
+                                            @csrf
+                                            @method('DELETE')
+
+                                            <button type="submit" class="btn btn-danger">フォロー解除</button>
+                                        </form>
+                                    @else
+                                        <form action="{{ route('users.follow', ['id' => $user->id]) }}" method="POST">
+                                            @csrf
+
+                                            <button type="submit" class="btn btn-primary">フォローする</button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+                @endforeach
+            </div>
+        </div>
+    </div>
 @endsection

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -22,10 +22,16 @@ Auth::routes();
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 Route::group(['middleware' => 'auth'], function() {
     Route::group(['prefix' => 'user', 'as' => 'user.'], function() {
-        Route::get('/', [App\Http\Controllers\UserController::class, 'getAll'])->name('index');
         Route::get('/{id}', [App\Http\Controllers\UserController::class, 'show'])->name('show');
         Route::put('/{id}', [App\Http\Controllers\UserController::class, 'update'])->name('update');
         Route::delete('/{id}', [App\Http\Controllers\UserController::class, 'delete'])->name('delete');
+    });
+    Route::group(['prefix' => 'users', 'as' => 'users.'], function() {
+        Route::get('/', [App\Http\Controllers\UserController::class, 'getAll'])->name('index');
+        Route::post('/follow/{id}', [App\Http\Controllers\UserController::class, 'follow'])->name('follow');
+        Route::delete('/follow/{id}', [App\Http\Controllers\UserController::class, 'unfollow'])->name('unfollow');
+        Route::get('/follower', [App\Http\Controllers\UserController::class, 'getAllFollowers'])->name('getFollowers');
+        Route::get('/followed', [App\Http\Controllers\UserController::class, 'getFollowedUsers'])->name('getFollowedUsers');
     });
     Route::group(['prefix' => 'tweets', 'as' => 'tweet.'], function() {
         Route::post('/', [App\Http\Controllers\TweetController::class, 'createTweet'])->name('createTweet');

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\TweetController;
+use App\Http\Controllers\UserController;
 
 /*
 |--------------------------------------------------------------------------
@@ -19,27 +22,27 @@ Route::get('/', function () {
 
 Auth::routes();
 
-Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
+Route::get('/home', [HomeController::class, 'index'])->name('home');
 Route::group(['middleware' => 'auth'], function() {
     Route::group(['prefix' => 'user', 'as' => 'user.'], function() {
-        Route::get('/{id}', [App\Http\Controllers\UserController::class, 'show'])->name('show');
-        Route::put('/{id}', [App\Http\Controllers\UserController::class, 'update'])->name('update');
-        Route::delete('/{id}', [App\Http\Controllers\UserController::class, 'delete'])->name('delete');
+        Route::get('/{id}', [UserController::class, 'show'])->name('show');
+        Route::put('/{id}', [UserController::class, 'update'])->name('update');
+        Route::delete('/{id}', [UserController::class, 'delete'])->name('delete');
     });
     Route::group(['prefix' => 'users', 'as' => 'users.'], function() {
-        Route::get('/', [App\Http\Controllers\UserController::class, 'getAll'])->name('index');
-        Route::post('/follow/{id}', [App\Http\Controllers\UserController::class, 'follow'])->name('follow');
-        Route::delete('/follow/{id}', [App\Http\Controllers\UserController::class, 'unfollow'])->name('unfollow');
-        Route::get('/follower', [App\Http\Controllers\UserController::class, 'getAllFollowers'])->name('getFollowers');
-        Route::get('/followed', [App\Http\Controllers\UserController::class, 'getFollowedUsers'])->name('getFollowedUsers');
+        Route::get('/', [UserController::class, 'getAll'])->name('index');
+        Route::get('/follower', [UserController::class, 'getAllFollowers'])->name('getFollowers');
+        Route::get('/followed', [UserController::class, 'getFollowedUsers'])->name('getFollowedUsers');
+        Route::post('/follow/{id}', [UserController::class, 'follow'])->name('follow');
+        Route::delete('/follow/{id}', [UserController::class, 'unfollow'])->name('unfollow');
     });
     Route::group(['prefix' => 'tweets', 'as' => 'tweet.'], function() {
-        Route::post('/', [App\Http\Controllers\TweetController::class, 'createTweet'])->name('createTweet');
-        Route::get('/', [App\Http\Controllers\TweetController::class, 'getAll'])->name('getAll');
-        Route::get('/create', [App\Http\Controllers\TweetController::class, 'create'])->name('create');
-        Route::get('/{id}', [App\Http\Controllers\TweetController::class, 'show'])->name('detail');
-        Route::get('/{id}/edit', [App\Http\Controllers\TweetController::class, 'edit'])->name('edit');
-        Route::put('/{id}', [App\Http\Controllers\TweetController::class, 'update'])->name('update');
-        Route::delete('/{id}', [App\Http\Controllers\TweetController::class, 'delete'])->name('delete');
+        Route::post('/', [TweetController::class, 'createTweet'])->name('createTweet');
+        Route::get('/', [TweetController::class, 'getAll'])->name('getAll');
+        Route::get('/create', [TweetController::class, 'create'])->name('create');
+        Route::get('/{id}', [TweetController::class, 'show'])->name('detail');
+        Route::get('/{id}/edit', [TweetController::class, 'edit'])->name('edit');
+        Route::put('/{id}', [TweetController::class, 'update'])->name('update');
+        Route::delete('/{id}', [TweetController::class, 'delete'])->name('delete');
     });
 });


### PR DESCRIPTION
# 関連チケット
・ユーザーのフォローができる
・フォロワー一覧が見られる
・フォロー一覧が見られる

# 検証内容
以下目視で確認しました。

＜ユーザーA＞
１. ユーザー一覧上で、各々のユーザーに「フォローする」ボタンを設置
２. ユーザーBをフォローすると、「フォロー解除」ボタンに切り替わる
３. フォロー一覧のページ上にユーザーBが表示される

＜ユーザーB＞
１. ユーザー一覧上で、ユーザーAの名前の横に「フォローされています」と表示
２. フォロワー一覧のページにユーザーAが表示される。