### PR TITLE
#8 リプライ機能の実装

### DIFF
--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\createReplyRequest;
 use App\Models\Reply;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
@@ -11,25 +12,25 @@ class ReplyController extends Controller
     /**
      * 新規リプライ
      *
-     * @param Request $request
-     * @param Int $tweetId
+     * @param CreateReplyRequest $request
+     * @param integer $tweetId
      * @param Reply $reply
-     * @return void
+     * @return RedirectResponse
      */
-    public function createReply(Request $request, Int $tweetId, Reply $reply): RedirectResponse
+    public function createReply(CreateReplyRequest $request, int $tweetId, Reply $reply): RedirectResponse
     {
-        $postReply = $reply->postReply($request->input('reply'), $tweetId);
+        $reply->storeReply($request->input('reply'), $tweetId);
         return back();
     }
 
     /**
      * リプライを削除
      *
-     * @param Int $replyId
+     * @param integer $replyId
      * @param Reply $reply
      * @return RedirectResponse
      */
-    public function deleteReply(Int $replyId, Reply $reply): RedirectResponse
+    public function deleteReply(int $replyId, Reply $reply): RedirectResponse
     {
         $deleteReply = $reply->deleteReply($replyId);
         return back();
@@ -46,9 +47,8 @@ class ReplyController extends Controller
     {
         $userId = auth()->id();
         $editReply = $request->input('reply');
-        $editReplyId = intval($request->input('replyId'));
-        $postEdit = $reply->editReply($userId, $editReply, $editReplyId);
-
+        $editReplyId = $request->id;
+        $reply->editReply($userId, $editReply, $editReplyId);
         return back();
     }
 }

--- a/twitter/app/Http/Controllers/ReplyController.php
+++ b/twitter/app/Http/Controllers/ReplyController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Reply;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+
+class ReplyController extends Controller
+{
+    /**
+     * 新規リプライ
+     *
+     * @param Request $request
+     * @param Int $tweetId
+     * @param Reply $reply
+     * @return void
+     */
+    public function createReply(Request $request, Int $tweetId, Reply $reply): RedirectResponse
+    {
+        $postReply = $reply->postReply($request->input('reply'), $tweetId);
+        return back();
+    }
+
+    /**
+     * リプライを削除
+     *
+     * @param Int $replyId
+     * @param Reply $reply
+     * @return RedirectResponse
+     */
+    public function deleteReply(Int $replyId, Reply $reply): RedirectResponse
+    {
+        $deleteReply = $reply->deleteReply($replyId);
+        return back();
+    }
+
+    /**
+     * リプライの編集
+     *
+     * @param Request $request
+     * @param Reply $reply
+     * @return RedirectResponse
+     */
+    public function editReply(Request $request, Reply $reply): RedirectResponse
+    {
+        $userId = auth()->id();
+        $editReply = $request->input('reply');
+        $editReplyId = intval($request->input('replyId'));
+        $postEdit = $reply->editReply($userId, $editReply, $editReplyId);
+
+        return back();
+    }
+}

--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\CreateTweetRequest;
+use App\Models\Reply;
 use App\Models\Tweet;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 
@@ -54,16 +56,20 @@ class TweetController extends Controller
     }
 
     /**
-     * 指定されたツイートIDに一致するツイートを取得し、ビューに渡すメソッド
+     * 指定されたツイートIDに一致するツイートとリプライを取得し、ビューに渡すメソッド
      *
      * @param Int $tweetId
      * @param Tweet $tweet
      * @return View
      */
-    public function show(Int $tweetId, Tweet $tweet): View
+    public function show(Int $tweetId, Tweet $tweet, Reply $reply): View
     {
         $tweetDetail = $tweet->findByTweetId($tweetId);
-        return view('tweet.show', ['tweetDetail' => $tweetDetail]);
+        $allReply = $reply->getAllReply($tweetId);
+        return view('tweet.show', [
+            'tweetDetail' => $tweetDetail,
+            'allReply' => $allReply,
+        ]);
     }
 
     /**
@@ -104,6 +110,5 @@ class TweetController extends Controller
     {
         $tweet->deleteTweet($tweetId);
         return redirect('tweets');
-
     }
 }

--- a/twitter/app/Http/Requests/CreateReplyRequest.php
+++ b/twitter/app/Http/Requests/CreateReplyRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションルール
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'reply' => 'required|max:140',
+        ];
+    }
+
+    /**
+     * バリデーション項目名定義
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'reply' => 'リプライ'
+        ];
+    }
+
+    /**
+     * バリデーションメッセージ
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [
+            'reply.required' => ':attributeを入力してください',
+            'reply.max' => ':attributeは140文字以内で入力してください',
+        ];
+    }
+}

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -8,32 +8,36 @@ use Illuminate\Database\Eloquent\Model;
 
 class Reply extends Model
 {
-    protected $table = 'replys';
+    protected $table = 'replies';
 
-    protected $fillable = ['user_id', 'content'];
+    protected $fillable = [
+        'user_id',
+        'content',
+        'tweet_id',
+    ];
 
     /**
      * リプライを作成
      *
-     * @param String $postReply
-     * @param Int $tweetId
+     * @param string $storeReply
+     * @param integer $tweetId
      * @return void
      */
-    public function postReply(String $postReply, Int $tweetId)
+    public function storeReply(string $storeReply, int $tweetId)
     {
         $this->user_id = auth()->id();
         $this->tweet_id = $tweetId;
-        $this->content = $postReply;
+        $this->content = $storeReply;
         return $this->save();
     }
 
     /**
      * ツイート毎にすべてのリプライを取得
      *
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @return Collection
      */
-    public function getAllReply(Int $tweetId): Collection
+    public function getAllReply(int $tweetId): Collection
     {
         return $allReplys = $this::where('tweet_id', $tweetId)->get();
     }
@@ -41,10 +45,10 @@ class Reply extends Model
     /**
      * リプライ削除
      *
-     * @param Int $replyId
+     * @param integer $replyId
      * @return void
      */
-    public function deleteReply(Int $replyId)
+    public function deleteReply(int $replyId)
     {
         $deleteReply = $this->findOrFail($replyId);
         return $deleteReply->delete();
@@ -53,12 +57,12 @@ class Reply extends Model
     /**
      * リプライを編集
      *
-     * @param Int $userId
-     * @param String $editReply
-     * @param Int $editReplyId
+     * @param integer $userId
+     * @param string $editReply
+     * @param string $editReplyId
      * @return boolean
      */
-    public function editReply(Int $userId, String $editReply, Int $editReplyId): bool
+    public function editReply(int $userId, string $editReply, string $editReplyId): bool
     {
         return $reply = $this->where('id', '=', $editReplyId)->update([
             'content' => $editReply

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Reply extends Model
+{
+    protected $table = 'replys';
+
+    protected $fillable = ['user_id', 'content'];
+
+    /**
+     * リプライを作成
+     *
+     * @param String $postReply
+     * @param Int $tweetId
+     * @return void
+     */
+    public function postReply(String $postReply, Int $tweetId)
+    {
+        $this->user_id = auth()->id();
+        $this->tweet_id = $tweetId;
+        $this->content = $postReply;
+        return $this->save();
+    }
+
+    /**
+     * ツイート毎にすべてのリプライを取得
+     *
+     * @param Int $tweetId
+     * @return Collection
+     */
+    public function getAllReply(Int $tweetId): Collection
+    {
+        return $allReplys = $this::where('tweet_id', $tweetId)->get();
+    }
+
+    /**
+     * リプライ削除
+     *
+     * @param Int $replyId
+     * @return void
+     */
+    public function deleteReply(Int $replyId)
+    {
+        $deleteReply = $this->findOrFail($replyId);
+        return $deleteReply->delete();
+    }
+
+    /**
+     * リプライを編集
+     *
+     * @param Int $userId
+     * @param String $editReply
+     * @param Int $editReplyId
+     * @return boolean
+     */
+    public function editReply(Int $userId, String $editReply, Int $editReplyId): bool
+    {
+        return $reply = $this->where('id', '=', $editReplyId)->update([
+            'content' => $editReply
+        ]);
+    }
+}

--- a/twitter/app/Models/Reply.php
+++ b/twitter/app/Models/Reply.php
@@ -50,7 +50,7 @@ class Reply extends Model
      */
     public function deleteReply(int $replyId)
     {
-        $deleteReply = $this->findOrFail($replyId);
+        $deleteReply = $this->find($replyId);
         return $deleteReply->delete();
     }
 

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -69,7 +69,7 @@ class Tweet extends Model
      *
      * @param Int $tweetId
      * @return boolean
-     *
+     */
     public function deleteTweet(Int $tweetId): bool
     {
         $deleteTweet = $this->findOrFail($tweetId);

--- a/twitter/database/migrations/2023_08_24_070321_create_replys_table.php
+++ b/twitter/database/migrations/2023_08_24_070321_create_replys_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replys', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->comment('ユーザーID');
+            $table->unsignedInteger('tweet_id')->comment('ツイートID');
+            $table->string('content')->comment('コメント本文');
+            $table->softDeletes();
+
+            $table->timestamps();
+
+            $table->foreign('user_id') // users テーブルの id カラムと関連付けられる外部キー
+                ->references('id') // 外部キーが参照するカラムを指定。この場合、user_idカラムが usersテーブルのidカラムを参照します。
+                ->on('users') //外部キーが参照するテーブルを指定します。この場合、user_idカラムがusersテーブルを参照。
+                ->onDelete('cascade') // 親テーブルのレコードが削除（または更新）された場合に、子テーブルの該当するレコードも一緒に削除する動作を定義します。
+                ->onUpdate('cascade'); // この場合、users テーブルの特定のユーザが削除された際に、関連するツイートも削除されます。
+
+            $table->foreign('tweet_id')
+                ->references('id')
+                ->on('tweets')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replys');
+    }
+};

--- a/twitter/database/migrations/2023_08_28_074612_create_replies_table.php
+++ b/twitter/database/migrations/2023_08_28_074612_create_replies_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('replys', function (Blueprint $table) {
+        Schema::create('replies', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id')->comment('ユーザーID');
             $table->unsignedInteger('tweet_id')->comment('ツイートID');
@@ -43,6 +43,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('replys');
+        Schema::dropIfExists('replies');
     }
 };

--- a/twitter/public/css/style.css
+++ b/twitter/public/css/style.css
@@ -1,3 +1,27 @@
 .loved {
     color: red;
 }
+
+.edit-btn,
+.delete-btn
+{
+    font-size: 18px;
+    color: gray;
+    background: transparent;
+    border: none;
+    padding: 12;
+    appearance: none;
+}
+
+.edit-formbtn {
+    margin-left: 10px;
+    padding: 6px;
+}
+
+.edit-formarea {
+    padding: 6px;
+}
+
+.reply-content {
+    padding: 8px;
+}

--- a/twitter/public/js/reply.js
+++ b/twitter/public/js/reply.js
@@ -1,0 +1,16 @@
+$(function () {
+    $('.edit-btn').click(function (e) {
+        e.preventDefault();
+
+        const replyId = $(this).data('reply-id');
+        const replyContent = $('#reply-content-' + replyId).text();
+        $('#reply-content-' + replyId).css('display', 'none');
+        $('.edit-formarea-' + replyId)
+            .val(replyContent)
+            .css('display', '')
+            .focus();
+        $('.edit-form-button-' + replyId)
+            .css('display', '')
+            .val('送信');
+    });
+});

--- a/twitter/resources/css/app.css
+++ b/twitter/resources/css/app.css
@@ -1,3 +1,0 @@
-.loved{
-    color: red;
-}

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -20,21 +20,18 @@
                     <div class='card-body'>
                         {{ $tweetDetail->content }}
                         <div class="d-flex justify-content-end flex-grow-1">
-                            @if (!auth()->user()->isFavorite(Auth::user()->id, $tweetDetail->id))
-                                <p class="favorite-marke">
-                                    <a class="js-like-toggle loved" href="" data-tweetid="{{ $tweetDetail->id }}">
-                                        <i class="fas fa-heart"></i>
-                                    </a>
-                                </p>
-                            @else
-                                <p class="favorite-marke">
-                                    <a class="js-like-toggle" href="" data-tweetid="{{ $tweetDetail->id }}">
-                                        <i class="fas fa-heart"></i>
-                                    </a>
-                                    {{-- <span class="favoriteCount"></span> --}}
-                                </p>
-                            @endif
+                            @php
+                                $isFavorite = auth()
+                                    ->user()
+                                    ->isFavorite($tweetDetail->id);
+                            @endphp
 
+                            <p class="favorite-marke">
+                                <a class="js-like-toggle {{ $isFavorite ? 'loved' : '' }}" href=""
+                                    data-tweetid="{{ $tweetDetail->id }}">
+                                    <i class="fas fa-heart"></i>
+                                </a>
+                            </p>
                             <p>
                                 <button type="submit" class="btn btn-danger">
                                     <a href="{{ route('tweet.edit', ['id' => $tweetDetail]) }}">編集する</a>
@@ -47,13 +44,70 @@
                                 <button type="submit" class="btn btn-danger">削除</button>
                             </form>
                             </p>
+                        </div>
 
-
+                        <div class="d-flex justify-content-end flex-grow-1">
+                            <form action="{{ route('tweet.reply', ['id' => $tweetDetail->id]) }}" method="POST">
+                                @csrf
+                                <input type="text" name='reply' placeholder="返信する">
+                                <button type="submit">返信</button>
+                            </form>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
+    </div>
+    <div class='container'>
+        <div class='row justify-content-center'>
+            <h3>↓コメントです</h3>
+            @foreach ($allReply as $reply)
+                <div class='col-md-8 mb-3'>
+                    <div class='card'>
+                        <div class="card-haeder p-3 w-100 d-flex">
+                            <img src="" class="rounded-circle" width="50" height="50">
+                            <div class="ml-2 d-flex flex-column">
+                                <p class="mb-0">{{ Auth::user()->name }}</p>
+                                <a href="" class="text-secondary"></a>
+                            </div>
+                            <div class="d-flex justify-content-end flex-grow-1">
+                                <p class="mb-0 text-secondary">{{ $reply->created_at }}</p>
+                            </div>
+                        </div>
+                        <div class='card-body'>
+                            <div>
+                                <p class='reply-content' id='reply-content-{{ $reply->id }}'>{{ $reply->content }}</p>
+
+                                <form action="{{ route('tweet.editreply', ['id' => $reply->id]) }}" method="POST">
+                                    @csrf
+                                    @method('PUT')
+                                    <input type="hidden" name="replyId" value="{{ $reply->id }}">
+                                    <input class="edit-formarea edit-formarea-{{ $reply->id }}" name="reply"
+                                        style="display:none"></input>
+                                    <input class="edit-formbtn edit-form-button-{{ $reply->id }}" type="submit"
+                                        style="display:none" value='送信'>
+                                </form>
+                                </p>
+                            </div>
+                            <div class="d-flex justify-content-end flex-grow-1">
+                                <button type="submit" class="edit-btn" data-reply-id="{{ $reply->id }}">
+                                    <i class="fa-regular fa-pen-to-square"></i>
+                                </button>
+
+                                <form action="{{ route('tweet.deletereply', ['id' => $reply->id]) }}" method="POST">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="delete-btn">
+                                        <i class="fa-regular fa-trash-can"></i>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+<script src="{{ asset('/js/reply.js') }}"></script>
 @endsection()

--- a/twitter/resources/views/tweet/show.blade.php
+++ b/twitter/resources/views/tweet/show.blade.php
@@ -51,6 +51,9 @@
                                 @csrf
                                 <input type="text" name='reply' placeholder="返信する">
                                 <button type="submit">返信</button>
+                                @foreach ($errors->all() as $error)
+                                    <p>{{ $error }}</p>
+                                @endforeach
                             </form>
                         </div>
                     </div>
@@ -82,9 +85,8 @@
                                 <form action="{{ route('tweet.editreply', ['id' => $reply->id]) }}" method="POST">
                                     @csrf
                                     @method('PUT')
-                                    <input type="hidden" name="replyId" value="{{ $reply->id }}">
                                     <input class="edit-formarea edit-formarea-{{ $reply->id }}" name="reply"
-                                        style="display:none"></input>
+                                        style="display:none">
                                     <input class="edit-formbtn edit-form-button-{{ $reply->id }}" type="submit"
                                         style="display:none" value='送信'>
                                 </form>
@@ -109,5 +111,5 @@
             @endforeach
         </div>
     </div>
-<script src="{{ asset('/js/reply.js') }}"></script>
+    <script src="{{ asset('/js/reply.js') }}"></script>
 @endsection()

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -1,10 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\FavoriteController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\ReplyController;
 use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
-use App\Http\Controllers\FavoriteController;
 
 /*
 |--------------------------------------------------------------------------
@@ -47,8 +48,8 @@ Route::group(['middleware' => 'auth'], function() {
         Route::get('/{id}/edit', [TweetController::class, 'edit'])->name('edit');
         Route::put('/{id}', [TweetController::class, 'update'])->name('update');
         Route::delete('/{id}', [TweetController::class, 'delete'])->name('delete');
-        Route::post('/reply/{id}', [TweetController::class, 'createReply'])->name('reply');
-        Route::delete('/reply/{id}', [TweetController::class, 'deleteReply'])->name('deletereply');
-        Route::put('/reply/{id}', [TweetController::class, 'editReply'])->name('editreply');
+        Route::post('/reply/{id}', [ReplyController::class, 'createReply'])->name('reply');
+        Route::delete('/reply/{id}', [ReplyController::class, 'deleteReply'])->name('deletereply');
+        Route::put('/reply/{id}', [ReplyController::class, 'editReply'])->name('editreply');
     });
 });

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -47,5 +47,8 @@ Route::group(['middleware' => 'auth'], function() {
         Route::get('/{id}/edit', [TweetController::class, 'edit'])->name('edit');
         Route::put('/{id}', [TweetController::class, 'update'])->name('update');
         Route::delete('/{id}', [TweetController::class, 'delete'])->name('delete');
+        Route::post('/reply/{id}', [TweetController::class, 'createReply'])->name('reply');
+        Route::delete('/reply/{id}', [TweetController::class, 'deleteReply'])->name('deletereply');
+        Route::put('/reply/{id}', [TweetController::class, 'editReply'])->name('editreply');
     });
 });


### PR DESCRIPTION
# 関連チケット
・ツイートにリプライができる
・ツイートのリプライを表示できる
・ツイートのリプライを削除できる

# 検証内容
投稿ツイートに対しリプライができる機能を追加しました。

・ツイート詳細画面に、リプライ用のフォームを設置。
・フォームからリプライすると、ツイート詳細画面上にリプライが表示される。
・投稿したリプライの横にある「編集」アイコンを押すと、トグルフォームが出現し編集可
・「削除」アイコンでリプライ削除