### PR TITLE
ツイート検索機能とページネーション追加

### DIFF
--- a/twitter/app/Http/Controllers/TweetController.php
+++ b/twitter/app/Http/Controllers/TweetController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\CreateQueryRequest;
 use App\Http\Requests\CreateTweetRequest;
 use App\Models\Reply;
 use App\Models\Tweet;
@@ -51,18 +52,18 @@ class TweetController extends Controller
      */
     public function getAll(Tweet $tweet): View
     {
-        $allTweets = $tweet->getAll(auth()->id());
+        $allTweets = $tweet->getAll();
         return view('tweet.index', ['allTweets' => $allTweets]);
     }
 
     /**
      * 指定されたツイートIDに一致するツイートとリプライを取得し、ビューに渡すメソッド
      *
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @param Tweet $tweet
      * @return View
      */
-    public function show(Int $tweetId, Tweet $tweet, Reply $reply): View
+    public function show(int $tweetId, Tweet $tweet, Reply $reply): View
     {
         $tweetDetail = $tweet->findByTweetId($tweetId);
         $allReply = $reply->getAllReply($tweetId);
@@ -75,11 +76,11 @@ class TweetController extends Controller
     /**
      * ツイート編集画面
      *
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @param Tweet $tweet
      * @return View
      */
-    public function edit(Int $tweetId, Tweet $tweet): View
+    public function edit(int $tweetId, Tweet $tweet): View
     {
         $tweets = $tweet->findByTweetId($tweetId);
         return view('tweet.edit', ['tweets' => $tweets]);
@@ -89,11 +90,11 @@ class TweetController extends Controller
      * ツイート編集処理
      *
      * @param CreateTweetRequest $request
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @param Tweet $tweet
      * @return RedirectResponse
      */
-    public function update(CreateTweetRequest $request, Int $tweetId, Tweet $tweet): RedirectResponse
+    public function update(CreateTweetRequest $request, int $tweetId, Tweet $tweet): RedirectResponse
     {
         $tweet->updateTweet($request->all());
         return redirect('tweets');
@@ -102,13 +103,28 @@ class TweetController extends Controller
     /**
      * ツイート削除処理
      *
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @param Tweet $tweet
      * @return RedirectResponse
      */
-    public function delete(Int $tweetId, Tweet $tweet): RedirectResponse
+    public function delete(int $tweetId, Tweet $tweet): RedirectResponse
     {
         $tweet->deleteTweet($tweetId);
         return redirect('tweets');
+    }
+
+    /**
+     * 検索ワードに紐づく投稿を検索
+     *
+     * @param CreateQueryRequest $request
+     * @param Tweet $tweet
+     * @return View
+     */
+    public function searchByQuery(CreateQueryRequest $request, Tweet $tweet): View
+    {
+        $searchQuery = $request->input('searchQuery');
+        $getSearchTweets = $tweet->searchByQuery($searchQuery);
+
+        return view('tweet.searchResult', compact('searchQuery', 'getSearchTweets'));
     }
 }

--- a/twitter/app/Http/Requests/CreateQueryRequest.php
+++ b/twitter/app/Http/Requests/CreateQueryRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateQueryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションルール
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'searchQuery' => 'required',
+        ];
+    }
+
+    /**
+     * バリデーション項目名定義
+     *
+     * @return void
+     */
+    public function attributes()
+    {
+        return [
+            'searchQuery' => '検索ワード',
+        ];
+    }
+
+    /**
+     * バリデーションメッセージ
+     *
+     * @return void
+     */
+    public function messages()
+    {
+        return [
+            'searchQuery.required' => ':attributeを入力してください',
+        ];
+    }
+}

--- a/twitter/app/Http/Requests/CreateQueryRequest.php
+++ b/twitter/app/Http/Requests/CreateQueryRequest.php
@@ -29,18 +29,6 @@ class CreateQueryRequest extends FormRequest
     }
 
     /**
-     * バリデーション項目名定義
-     *
-     * @return void
-     */
-    public function attributes()
-    {
-        return [
-            'searchQuery' => '検索ワード',
-        ];
-    }
-
-    /**
      * バリデーションメッセージ
      *
      * @return void
@@ -48,7 +36,7 @@ class CreateQueryRequest extends FormRequest
     public function messages()
     {
         return [
-            'searchQuery.required' => ':attributeを入力してください',
+            'searchQuery.required' => '検索キーワードを入力してください',
         ];
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -48,7 +48,7 @@ class Tweet extends Model
      */
     public function findByTweetId(int $tweetId): Tweet
     {
-        return $this->findOrFail($tweetId);
+        return $this->find($tweetId);
     }
 
     /**

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Collection\array;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\softDeletes;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class Tweet extends Model
 {
@@ -18,11 +19,11 @@ class Tweet extends Model
     /**
      * 新規ツイートを保存
      *
-     * @param Int $userId
-     * @param string $postTweet
+     * @param integer $userId
+     * @param string $createTweet
      * @return boolean
      */
-    public function create(Int $userId, string $createTweet): bool
+    public function create(int $userId, string $createTweet): bool
     {
         $this->user_id = $userId;
         $this->content = $createTweet;
@@ -32,21 +33,20 @@ class Tweet extends Model
     /**
      * すべてのツイートを取得
      *
-     * @param Int $userId
-     * @return \Illuminate\Database\Eloquent\Collection|array
+     * @return LengthAwarePaginator
      */
-    public function getAll(Int $userId)
+    public function getAll(): LengthAwarePaginator
     {
-        return $this->where('user_id', $userId)->get();
+        return $this::orderBy('created_at', 'desc')->paginate(10);
     }
 
     /**
      * 指定されたツイートIDに一致するツイートを取得
      *
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @return Tweet
      */
-    public function findByTweetId(Int $tweetId): Tweet
+    public function findByTweetId(int $tweetId): Tweet
     {
         return $this->findOrFail($tweetId);
     }
@@ -67,10 +67,10 @@ class Tweet extends Model
     /**
      * ツイートをデータベースから削除
      *
-     * @param Int $tweetId
+     * @param integer $tweetId
      * @return boolean
      */
-    public function deleteTweet(Int $tweetId): bool
+    public function deleteTweet(int $tweetId): bool
     {
         $deleteTweet = $this->findOrFail($tweetId);
         return $deleteTweet->delete();
@@ -80,14 +80,38 @@ class Tweet extends Model
     /**
      * ログイン中のユーザーがいいねしたツイートを取得
      *
-     * @param Int $userId
+     * @param integer $userId
      * @return Collection
      */
-    public function getAllFavoriteTweets(Int $userId): Collection
+    public function getAllFavoriteTweets(int $userId): Collection
     {
         // ①favoriteテーブルにおいて、user_idで絞り込み。tweet_idのみ取得
         $favoriteTweets = Favorite::where('user_id', $userId)->pluck('tweet_id')->toArray();
         // ②絞り込んだfavoriteのtweet_idをもとに、紐付くtweetを取得
         return $tweets = Tweet::whereIn('id', $favoriteTweets)->get();
+    }
+
+    /**
+     * 検索ワードに紐づくデータをDBより取得
+     *
+     * @param string $searchQuery
+     * @return LengthAwarePaginator
+     */
+    public function searchByQuery(string $searchQuery): LengthAwarePaginator
+    {
+        $getTweetQuery = $this::query();
+
+        if(!empty($searchQuery)) {
+            // $searchQueryの中身が空で無い場合処理実行
+            $searchTweet = $getTweetQuery
+                ->where('content', 'LIKE', "%{$searchQuery}%")
+                ->orderBy('created_at', 'desc')
+                ->paginate(10);
+
+            return $searchTweet;
+        }
+
+        $queryTweet = $getTweetQuery->paginate(10);
+        return $queryTweet;
     }
 }

--- a/twitter/app/Models/Tweet.php
+++ b/twitter/app/Models/Tweet.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Favorite;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Collection\array;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -37,7 +38,7 @@ class Tweet extends Model
      */
     public function getAll(): LengthAwarePaginator
     {
-        return $this::orderBy('created_at', 'desc')->paginate(10);
+        return $this->orderBy('created_at', 'desc')->paginate(config('paginate.paginate'));
     }
 
     /**
@@ -59,23 +60,10 @@ class Tweet extends Model
      */
     public function updateTweet(array $updateTweet): bool
     {
-        $this->content = $updateTweet['tweet'];
-        $this->user_id = $updateTweet['user_id'];
+        $this->content = $updateTweet;
+        $this->user_id = auth()->id();
         return $this->update();
     }
-
-    /**
-     * ツイートをデータベースから削除
-     *
-     * @param integer $tweetId
-     * @return boolean
-     */
-    public function deleteTweet(int $tweetId): bool
-    {
-        $deleteTweet = $this->findOrFail($tweetId);
-        return $deleteTweet->delete();
-    }
-
 
     /**
      * ログイン中のユーザーがいいねしたツイートを取得
@@ -97,21 +85,14 @@ class Tweet extends Model
      * @param string $searchQuery
      * @return LengthAwarePaginator
      */
-    public function searchByQuery(string $searchQuery): LengthAwarePaginator
+    public function searchByQuery(string $query): LengthAwarePaginator
     {
         $getTweetQuery = $this::query();
 
-        if(!empty($searchQuery)) {
-            // $searchQueryの中身が空で無い場合処理実行
-            $searchTweet = $getTweetQuery
-                ->where('content', 'LIKE', "%{$searchQuery}%")
-                ->orderBy('created_at', 'desc')
-                ->paginate(10);
-
-            return $searchTweet;
-        }
-
-        $queryTweet = $getTweetQuery->paginate(10);
-        return $queryTweet;
+        if($query) {
+            return $this->where('content', 'LIKE', "%{$query}%")
+                        ->orderBy('created_at', 'desc')
+                        ->paginate(config('paginate.paginate'));
+    }
     }
 }

--- a/twitter/app/Providers/AppServiceProvider.php
+++ b/twitter/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
+
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +25,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Paginator::useBootstrap();
     }
 }

--- a/twitter/config/paginate.php
+++ b/twitter/config/paginate.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Facade;
+
+return [
+    'paginate' => 10,
+];

--- a/twitter/resources/views/tweet/index.blade.php
+++ b/twitter/resources/views/tweet/index.blade.php
@@ -4,10 +4,12 @@
 
 @section('content')
     <div class='container'>
+        <h1>{{ isset($query) ? '検索結果' : 'ツイート一覧' }}</h1>
+
         <div class='row justify-content-center'>
             <p><a href="{{ route('tweet.getFavorite', ['userId' => Auth::id()]) }}">いいねした投稿一覧</a></p>
             <div>
-                <form action="{{ route('tweet.query') }}" method="GET">
+                <form action="{{ route('tweet.getAll') }}" method="GET">
                     <p>
                         <input type="text" name="searchQuery" value="" placeholder="検索">
                         <input type="submit" value="検索">
@@ -20,7 +22,7 @@
                     </p>
                 </form>
             </div>
-            @foreach ($allTweets as $tweet)
+            @foreach ($tweets as $tweet)
                 <div class='col-md-8 mb-3'>
                     <div class='card'>
                         <div class="card-haeder p-3 w-100 d-flex">
@@ -55,7 +57,7 @@
                 </div>
             @endforeach
             {{-- ツイート一覧のページネーション --}}
-            {{ $allTweets->links() }}
+            {{ $tweets->links() }}
         </div>
     </div>
 

--- a/twitter/resources/views/tweet/searchResult.blade.php
+++ b/twitter/resources/views/tweet/searchResult.blade.php
@@ -1,26 +1,15 @@
+
 @extends('layouts.app')
 
-@section('title', 'ホーム')
+@section('title', '検索一覧')
 
 @section('content')
     <div class='container'>
         <div class='row justify-content-center'>
-            <p><a href="{{ route('tweet.getFavorite', ['userId' => Auth::id()]) }}">いいねした投稿一覧</a></p>
+            <p>検索ワード：{{ $searchQuery }}</a></p>
             <div>
-                <form action="{{ route('tweet.query') }}" method="GET">
-                    <p>
-                        <input type="text" name="searchQuery" value="" placeholder="検索">
-                        <input type="submit" value="検索">
-                        <p>
-                             {{-- 検索フォームが空の状態でsubmitした時にバリデーションメッセージ表示 --}}
-                            @foreach ($errors->all() as $error)
-                                <p>{{ $error }}</p>
-                            @endforeach
-                        </p>
-                    </p>
-                </form>
             </div>
-            @foreach ($allTweets as $tweet)
+            @foreach ($getSearchTweets as $searchTweet)
                 <div class='col-md-8 mb-3'>
                     <div class='card'>
                         <div class="card-haeder p-3 w-100 d-flex">
@@ -30,23 +19,23 @@
                                 <a href="" class="text-secondary"></a>
                             </div>
                             <div class="d-flex justify-content-end flex-grow-1">
-                                <p class="mb-0 text-secondary">{{ $tweet->created_at }}</p>
+                                <p class="mb-0 text-secondary">{{ $searchTweet->created_at }}</p>
                             </div>
                         </div>
                         <div class='card-body'>
-                            {{ $tweet->content }}
+                            {{ $searchTweet->content }}
                             <div class="d-flex justify-content-end flex-grow-1">
                                 <p class="mb-0 text-secondary"><a
-                                        href="{{ route('tweet.detail', ['id' => $tweet->id]) }}">詳細を見る</a></p>
+                                        href="{{ route('tweet.detail', ['id' => $searchTweet->id]) }}">詳細を見る</a></p>
                             </div>
                             @php
                                 $isFavorite = auth()
                                     ->user()
-                                    ->isFavorite($tweet->id);
+                                    ->isFavorite($searchTweet->id);
                             @endphp
                             <p class="favorite-marke">
                                 <a class="js-like-toggle {{ $isFavorite ? 'loved' : '' }}" href=""
-                                    data-tweetid="{{ $tweet->id }}">
+                                    data-tweetid="{{ $searchTweet->id }}">
                                     <i class="fas fa-heart"></i>
                                 </a>
                             </p>
@@ -54,8 +43,7 @@
                     </div>
                 </div>
             @endforeach
-            {{-- ツイート一覧のページネーション --}}
-            {{ $allTweets->links() }}
+            {{ $getSearchTweets->appends(['searchQuery' => $searchQuery])->links() }}
         </div>
     </div>
 

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -41,6 +41,7 @@ Route::group(['middleware' => 'auth'], function() {
     Route::group(['prefix' => 'tweets', 'as' => 'tweet.'], function() {
         Route::post('/', [TweetController::class, 'createTweet'])->name('createTweet');
         Route::get('/', [TweetController::class, 'getAll'])->name('getAll');
+        Route::get('/search', [TweetController::class, 'searchByQuery'])->name('query');
         Route::get('/create', [TweetController::class, 'create'])->name('create');
         Route::get('/favorite', [FavoriteController::class, 'getAllByTweetIds'])->name('getFavorite');
         Route::post('/favorite/{favoriteTweetId}', [FavoriteController::class, 'favoriteTweet'])->name('favorite');

--- a/twitter/routes/web.php
+++ b/twitter/routes/web.php
@@ -41,7 +41,6 @@ Route::group(['middleware' => 'auth'], function() {
     Route::group(['prefix' => 'tweets', 'as' => 'tweet.'], function() {
         Route::post('/', [TweetController::class, 'createTweet'])->name('createTweet');
         Route::get('/', [TweetController::class, 'getAll'])->name('getAll');
-        Route::get('/search', [TweetController::class, 'searchByQuery'])->name('query');
         Route::get('/create', [TweetController::class, 'create'])->name('create');
         Route::get('/favorite', [FavoriteController::class, 'getAllByTweetIds'])->name('getFavorite');
         Route::post('/favorite/{favoriteTweetId}', [FavoriteController::class, 'favoriteTweet'])->name('favorite');


### PR DESCRIPTION
# 関連チケット
- 投稿のキーワード検索ができる
- ページネーション機能の実装

# キャプション
https://github.com/RyotaNishida/twitter-clone/assets/141088770/7cd0edfa-60e6-41f1-9a08-e997f31f7fd2

# 検証内容
- ツイート一覧画面上の検索フォームからキーワードを入力し、キーワードと一致するツイートが/tweets/searchページに表示されるのを目視で確認しました。
- ツイート一覧・検索結果一覧画面に、ツイート数に応じてページネーションが表示されるのを目視で確認しました（10ツイート以上でページネーション表示）

# 改修内容
- request取得時の記述修正（all())メソッドを使わない）
- 検索結果表示画面を別ページにリダイレクトさせず、ツイート一覧画面でレンダリングするよう修正
- config配下にpaginate.phpを作成しページネーション時のアイテム取得数を定義。ファイル内の数字直書きを防ぐため。
- その他コード修正